### PR TITLE
Branch/5.15 25.08

### DIFF
--- a/org.kde.WaylandDecoration.QAdwaitaDecorations.json
+++ b/org.kde.WaylandDecoration.QAdwaitaDecorations.json
@@ -1,10 +1,10 @@
 {
     "id": "org.kde.WaylandDecoration.QAdwaitaDecorations",
-    "branch": "5.15-24.08",
+    "branch": "5.15-25.08",
     "runtime": "org.kde.Platform",
     "build-extension": true,
     "sdk": "org.kde.Sdk",
-    "runtime-version": "5.15-24.08",
+    "runtime-version": "5.15-25.08",
     "separate-locales": false,
     "modules": [
         {


### PR DESCRIPTION
Since i've upgraded org.keepassxc.KeePassXC the window decoration on gnome are not correct anymore. As far as i can tell, the only difference it, that it changed from  5.15-24.08 to  5.15-25.08 as base. See:

https://github.com/flathub/org.keepassxc.KeePassXC/issues/153

<img width="1784" height="913" alt="528156960-f582984e-45c3-43d3-8fab-f08f644e3dea" src="https://github.com/user-attachments/assets/06467a6d-c416-4f01-85e4-27a3f352d1a1" />

I think this will solve my issue. I'll build it local and give feedback.